### PR TITLE
add openapi-inline-html deprecation message

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,44 +1,7 @@
 # openapi-inline-html
 
-Generate standalone HTML from OpenAPI Specification. 📗✨
+⚠️ **This package has been deprecated.**  
 
-## Feature
+This package has been renamed to openapi-generate-html. Please use the new package.
 
-One of the key benefits of `openapi-inline-html` is its portability.
-By generating a single, self-contained HTML file, all required assets (CSS, JavaScript, and OpenAPI data) are embedded directly in the document.
-This makes it easy to:
-
-1. **Share** : the file as a single, standalone document without additional dependencies.
-2. **Hosting** : the file on any server or serve it locally, with no need for additional resources or configurations.
-3. **Distribute** : the file via email or other methods, knowing that it will display consistently across environments.
-
-This portability makes `openapi-inline-html` ideal for situations where reliable, standalone documentation is required.
-
-## How to use
-
-```bash
-npx openapi-inline-html -i openapi.json
-```
-
-Use Dark theme 🌙
-
-```bash
-npx openapi-inline-html -i openapi.json --theme=dark
-```
-
-> [!NOTE]
-> The dark theme is an experimental feature 🧪
-
-## CLI Options
-
-| command       | default        | description                             |
-| ------------- | -------------- | --------------------------------------- |
-| --input (-i)  |                | Input OpenAPI JSON / YAML file path     |
-| --output (-o) | "openapi.html" | Output HTML file name                   |
-| --ui          | "stoplight"    | Choose UI (stoplight / swagger / redoc) |
-| --theme       | "light"        | Choose Theme (light / dark)             |
-| --title       | "OpenAPI Docs" | Title of the HTML page                  |
-
-## License
-
-This project is licensed under the terms of the [MIT license](./LICENSE).
+https://www.npmjs.com/package/openapi-generate-html

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openapi-inline-html",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openapi-inline-html",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^11.7.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-inline-html",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Generate standalone HTML from OpenAPI Specification",
   "bin": {
     "openapi-inline-html": "./index.mjs"


### PR DESCRIPTION
npm published.
https://www.npmjs.com/package/openapi-inline-html